### PR TITLE
Output an empty string if the field value is empty.

### DIFF
--- a/gravityforms-html-fields-merge-tags.php
+++ b/gravityforms-html-fields-merge-tags.php
@@ -45,6 +45,9 @@ class Breakfast_HTML_Fields_Merge_Tags{
 			if( ! empty( rgpost( 'input_' . $input_id ) ) ) {
 				$field_content = str_replace( $match[0], rgpost( 'input_' . $input_id ), $field_content );
 				continue;
+			} else {
+				// No value? Don't output anything. Needed for optional fields.
+				$field_content = str_replace( $match[0], '', $field_content );
 			}
 
 			/**


### PR DESCRIPTION
Adding the option to output an empty string if the field value is blank instead of outputting the {FIELD_LABEL:FIELD_ID}. This is good for optional fields.